### PR TITLE
Add initialize view lifecycle method

### DIFF
--- a/src/__demo__/earthquakes/demo-fixed.ts
+++ b/src/__demo__/earthquakes/demo-fixed.ts
@@ -41,6 +41,7 @@ content.appendChild(view.element);
 container.appendChild(content);
 
 document.body.appendChild(container);
+view.initialize();
 
 fetchEarthquakes().then((response) => {
     const features = response.features.map((f) => f.properties);

--- a/src/__demo__/earthquakes/demo.ts
+++ b/src/__demo__/earthquakes/demo.ts
@@ -29,6 +29,7 @@ const header = document.createElement("h1");
 header.appendChild(document.createTextNode("All earthquakes in the past day"));
 document.body.appendChild(header);
 document.body.appendChild(view.element);
+view.initialize();
 
 fetchEarthquakes().then((response) => {
     const features = response.features.map((f) => f.properties);

--- a/src/__demo__/mountains/demo.ts
+++ b/src/__demo__/mountains/demo.ts
@@ -46,3 +46,4 @@ subheader.appendChild(createToggle("Ultras", ULTRAS));
 document.body.appendChild(subheader);
 
 document.body.appendChild(view.element);
+view.initialize();

--- a/src/react/table.tsx
+++ b/src/react/table.tsx
@@ -117,6 +117,7 @@ export class Table<
     private handleRef = (element: HTMLElement | null) => {
         if (element) {
             element.appendChild(this.view.element);
+            this.view.initialize();
         }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,7 @@ export interface IViewConfig<
 
 export interface ITableView {
     readonly element: HTMLElement;
+    initialize(): void;
     destroy(): void;
 }
 

--- a/src/view/fixed-table.ts
+++ b/src/view/fixed-table.ts
@@ -73,6 +73,11 @@ export class FixedTableView<
         this.updateScroll();
     }
 
+    public initialize() {
+        this.updateWidths();
+        this.updateScroll();
+    }
+
     public destroy() {
         this.headerView.destroy();
         this.bodyView.destroy();

--- a/src/view/table.ts
+++ b/src/view/table.ts
@@ -21,6 +21,10 @@ export class TableView<
         this.element.appendChild(this.bodyView.element);
     }
 
+    public initialize() {
+        // no-op
+    }
+
     public destroy() {
         this.headerView.destroy();
         this.bodyView.destroy();


### PR DESCRIPTION
Add an `initialize` method to the table view that is meant to be called after the table is added to the DOM.  It was initially needed so that the fixed table column widths can be initialized to the correct widths.