### PR TITLE
Add default sort handling to React component

### DIFF
--- a/src/react/table.tsx
+++ b/src/react/table.tsx
@@ -132,6 +132,8 @@ export class Table<
         const { onSort } = this.props;
         if (onSort) {
             onSort(newSort);
+        } else if (!("sort" in this.props)) {
+            this.model.setSort(newSort);
         }
     }
 


### PR DESCRIPTION
If the sort is not explicitly specified or handled, automatically set it internally for ease of use.