### PR TITLE
Round scaled column widths to remove scrollbar

### DIFF
--- a/src/view/fixed-table.ts
+++ b/src/view/fixed-table.ts
@@ -112,7 +112,7 @@ export class FixedTableView<
         const scale = widthSum < bodyElementWidth ? bodyElementWidth / widthSum : 1;
 
         for (let index = 0; index < numCells; index++) {
-            const width = `${widths[index] * scale}px`;
+            const width = `${Math.round(widths[index] * scale)}px`;
             headerCells[index].style.minWidth = width;
             bodyCells[index].style.minWidth = width;
         }


### PR DESCRIPTION
In the fixed view, when column widths are scaled, the columns overflow the container and add a horizontal scrollbar, presumably due to rounding error.