### PR TITLE
Recalculate widths when fixed container is resized

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,12 @@
         }
       }
     },
+    "@types/element-resize-detector": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/element-resize-detector/-/element-resize-detector-1.1.2.tgz",
+      "integrity": "sha512-fi113VLkvw1NydG4N/T+dOZos1mO9Ij04CiKem1Pw9byb2e3YxGZS8CZ9hM6It1zjPzCrMm4gQ7P8jmVZkH7qQ==",
+      "dev": true
+    },
     "@types/jest": {
       "version": "23.3.10",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.10.tgz",
@@ -955,6 +961,11 @@
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
+    },
+    "batch-processor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
+      "integrity": "sha1-dclcMrdI4IUNEMKxaPa9vpiRrOg="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -2186,6 +2197,14 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.88.tgz",
       "integrity": "sha512-UPV4NuQMKeUh1S0OWRvwg0PI8ASHN9kBC8yDTk1ROXLC85W5GnhTRu/MZu3Teqx3JjlQYuckuHYXSUSgtb3J+A==",
       "dev": true
+    },
+    "element-resize-detector": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/element-resize-detector/-/element-resize-detector-1.2.0.tgz",
+      "integrity": "sha512-UmhNB8sIJVZeg56gEjgmMd6p37sCg8j8trVW0LZM7Wzv+kxQ5CnRHcgRKBTB/kFUSn3e7UP59kl2V2U8Du1hmg==",
+      "requires": {
+        "batch-processor": "1.0.0"
+      }
     },
     "elliptic": {
       "version": "6.4.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,11 @@
   "files": [
     "dist"
   ],
+  "dependencies": {
+    "element-resize-detector": "^1.2.0"
+  },
   "devDependencies": {
+    "@types/element-resize-detector": "^1.1.2",
     "@types/jest": "^23.3.10",
     "@types/react": "^16.7.1",
     "@types/react-dom": "^16.0.11",


### PR DESCRIPTION
Fixes #13 

Columns will now expand or contract as necessary if the width of the fixed table container changes.  Additionally, columns will now contract if possible when the rows change.