### PR TITLE
Support React content in table cells

### DIFF
--- a/src/__demo__/earthquakes/columns-react.tsx
+++ b/src/__demo__/earthquakes/columns-react.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import { IReactColumn } from "../../react";
+import { IGeoJsonFeatureProperties } from "./types";
+
+export const COLUMNS_REACT: Array<IReactColumn<IGeoJsonFeatureProperties>> = [
+    {
+        key: "time",
+        label: "Time",
+        renderData({time}) {
+            return new Date(time).toLocaleString();
+        },
+    },
+    {
+        key: "mag",
+        label: "Magnitude",
+        reactRenderData({mag}) {
+            const magFixed = mag.toFixed(1);
+            return mag >= 5 ? <strong>{magFixed}</strong> : magFixed;
+        },
+    },
+    {
+        key: "place",
+        label: "Location",
+    },
+    {
+        key: "url",
+        label: "Details",
+        reactRenderData({url}) {
+            return <a href={url} target="_blank">Details</a>;
+        },
+    },
+];

--- a/src/__demo__/earthquakes/demo-react.tsx
+++ b/src/__demo__/earthquakes/demo-react.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { Table } from "../../react";
 import { ISort } from "../../types";
-import { COLUMNS } from "./columns";
+import { COLUMNS_REACT } from "./columns-react";
 import { fetchEarthquakes } from "./data";
 import { IGeoJsonFeatureProperties } from "./types";
 
@@ -36,7 +36,7 @@ class Demo extends React.PureComponent<{}, IState> {
                 <Table
                     keyField="code"
                     rows={this.state.rows}
-                    columns={COLUMNS}
+                    columns={COLUMNS_REACT}
                     selection={this.state.selection}
                     selectionMode="multi"
                     sort={this.state.sort}

--- a/src/__tests__/view/dom-test.ts
+++ b/src/__tests__/view/dom-test.ts
@@ -1,4 +1,4 @@
-import { findParentElementOfType, getChildIndex, removeAllChildren, replaceWith } from "../../view/dom";
+import { applyStyles, findParentElementOfType, getChildIndex, removeAllChildren, replaceWith } from "../../view/dom";
 
 function createDiv() {
     return document.createElement("div");
@@ -91,6 +91,22 @@ describe("removeAllChildren", () => {
         const parent = createDiv();
         removeAllChildren(parent);
         expect(parent.childNodes.length).toBe(0);
+    });
+
+});
+
+describe("applyStyles", () => {
+
+    test("applys styles", () => {
+        const styles: Partial<CSSStyleDeclaration> = {
+            backgroundColor: "blue",
+            color: "red",
+        };
+        const div = createDiv();
+        applyStyles(div, styles);
+        for (const key in styles) { // tslint:disable-line:forin
+            expect(div.style[key]).toEqual(styles[key]);
+        }
     });
 
 });

--- a/src/__tests__/view/dom-test.ts
+++ b/src/__tests__/view/dom-test.ts
@@ -1,4 +1,4 @@
-import { findParentElementOfType, getChildIndex, replaceWith } from "../../view/dom";
+import { findParentElementOfType, getChildIndex, removeAllChildren, replaceWith } from "../../view/dom";
 
 function createDiv() {
     return document.createElement("div");
@@ -71,6 +71,26 @@ describe("getChildIndex", () => {
         expect(getChildIndex(child1)).toBe(0);
         expect(getChildIndex(child2)).toBe(1);
         expect(getChildIndex(child3)).toBe(2);
+    });
+
+});
+
+describe("removeAllChildren", () => {
+
+    test("removes all child nodes", () => {
+        const parent = createDiv();
+        const child1 = createDiv();
+        const child2 = createDiv();
+        parent.appendChild(child1);
+        parent.appendChild(child2);
+        removeAllChildren(parent);
+        expect(parent.childNodes.length).toBe(0);
+    });
+
+    test("does nothing if there are no child nodes", () => {
+        const parent = createDiv();
+        removeAllChildren(parent);
+        expect(parent.childNodes.length).toBe(0);
     });
 
 });

--- a/src/react/cell-content.tsx
+++ b/src/react/cell-content.tsx
@@ -1,0 +1,88 @@
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import { ITableModel, ITableView, ObjectWithKey } from "../..";
+import { removeAllChildren } from "../view/dom";
+import { IReactColumn } from "./types";
+
+interface ICellContentProps<
+    Key extends keyof Row,
+    Row extends ObjectWithKey<Key, KeyType>,
+    KeyType = Row[Key],
+> {
+    model: ITableModel<Key, Row, KeyType>;
+    view: ITableView;
+}
+
+interface ICellContentState {
+    portals: React.ReactPortal[];
+}
+
+export class CellContent<
+    Key extends keyof Row,
+    Row extends ObjectWithKey<Key, KeyType>,
+    KeyType = Row[Key],
+> extends React.PureComponent<ICellContentProps<Key, Row, KeyType>, ICellContentState> {
+
+    public state: ICellContentState = {
+        portals: [],
+    };
+
+    private domObserver?: MutationObserver;
+    private tbodyElement: HTMLElement | null = null;
+
+    public componentDidMount() {
+        this.domObserver = new MutationObserver(this.handleMutation);
+        this.domObserver.observe(this.props.view.element, { childList: true });
+    }
+
+    public componentWillUnmount() {
+        if (this.domObserver) {
+            this.domObserver.disconnect();
+        }
+    }
+
+    public render() {
+        return this.state.portals;
+    }
+
+    private handleMutation = () => {
+        const newTbodyElement = this.props.view.element.querySelector("tbody");
+        if (newTbodyElement !== this.tbodyElement) {
+            this.createPortals();
+            this.tbodyElement = newTbodyElement;
+        }
+    }
+
+    private createPortals() {
+        const { columns, sortedRows, keyField } = this.props.model;
+
+        const rowElements = this.props.view.element.querySelectorAll("tbody tr");
+        if (rowElements.length !== sortedRows.length) {
+            throw new Error("invariant violated, lengths differ");
+        }
+
+        const portals = [];
+
+        for (let rowIndex = 0; rowIndex < rowElements.length; rowIndex++) {
+            const row = sortedRows[rowIndex];
+            const rowKey = row[keyField];
+            const rowElement = rowElements[rowIndex];
+            for (let columnIndex = 0; columnIndex < columns.length; columnIndex++) {
+                const column: IReactColumn<Row> = columns[columnIndex];
+                if (!column.reactRenderData) {
+                    continue;
+                }
+                const child = column.reactRenderData(row);
+                const container = rowElement.childNodes[columnIndex] as Element;
+                const portalKey = `${JSON.stringify(rowKey)}:${column.key}`;
+                removeAllChildren(container);
+                // FIXME: Content is recreated, not remounted, and component state is lost.
+                // See: https://github.com/facebook/react/issues/13044
+                portals.push(ReactDOM.createPortal(child, container, portalKey));
+            }
+        }
+
+        this.setState({ portals });
+    }
+
+}

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,1 +1,2 @@
+export * from "./types";
 export * from "./table";

--- a/src/react/table.tsx
+++ b/src/react/table.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import {
     FixedTableView,
-    IColumn,
     ISort,
     ITableModel,
     ITableView,
+    IViewConfig,
     MultiSelectionAdapter,
     NOOP_SELECTION_ADAPTER,
     ObjectWithKey,
@@ -15,7 +15,8 @@ import {
     TableModel,
     TableView,
 } from "..";
-import { IViewConfig } from "../types";
+import { CellContent } from "./cell-content";
+import { IReactColumn } from "./types";
 
 function createSelectionAdapter<
     Key extends keyof Row,
@@ -43,7 +44,7 @@ export interface ITableProps<
 > {
     keyField: Key;
     rows: Row[];
-    columns: Array<IColumn<Row>>;
+    columns: Array<IReactColumn<Row>>;
     selection?: Set<KeyType>;
     selectionMode?: SelectionMode;
     sort?: ISort<Row>;
@@ -112,7 +113,11 @@ export class Table<
     }
 
     public render() {
-        return <div ref={this.handleRef} className={this.props.className} />;
+        return (
+            <div ref={this.handleRef} className={this.props.className}>
+                <CellContent model={this.model} view={this.view} />
+            </div>
+        );
     }
 
     private handleRef = (element: HTMLElement | null) => {

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -1,0 +1,6 @@
+import { ReactNode } from "react";
+import { IColumn } from "../types";
+
+export interface IReactColumn<Row> extends IColumn<Row> {
+    reactRenderData?(row: Row): ReactNode;
+}

--- a/src/view/dom.ts
+++ b/src/view/dom.ts
@@ -23,6 +23,12 @@ export function getChildIndex(element: Node) {
     return count;
 }
 
+export function removeAllChildren(node: Node) {
+    while (node.lastChild) {
+        node.removeChild(node.lastChild);
+    }
+}
+
 export function applyStyles(element: HTMLElement, styles: Partial<CSSStyleDeclaration>) {
     for (const key in styles) { // tslint:disable-line:forin
         const value = styles[key];


### PR DESCRIPTION
Add a new `IReactColumn` type with a `reactRenderData` field that returns a React node as the cell content.