### PR TITLE
Add data-column-key to headers

### DIFF
--- a/src/view/header.ts
+++ b/src/view/header.ts
@@ -96,6 +96,7 @@ export class TableHeaderView<
     private createThElement(column: IColumn<R>) {
         const th = document.createElement("th");
         th.style.boxSizing = "border-box";
+        th.setAttribute("data-column-key", column.key);
         th.appendChild(document.createTextNode(column.label || ""));
         return th;
     }


### PR DESCRIPTION
Add `data-column-key` attributes to the table header elements to be consistent with body cells.