### PR TITLE
Use Record type for rows

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -5,7 +5,6 @@ import {
     ISort,
     ITableConfig,
     ITableModel,
-    ObjectWithKey,
     RowEventListener,
     SelectionEventListener,
     SortEventListener
@@ -31,7 +30,7 @@ export function getSortableValue<R>(row: R, column: IColumn<R>) {
     }
 }
 
-export class TableModel<K extends keyof R, R extends ObjectWithKey<K, V>, V = R[K]> implements ITableModel<K, R, V> {
+export class TableModel<K extends keyof R, R extends Record<K, V>, V = R[K]> implements ITableModel<K, R, V> {
     public keyField: K;
     public columns: Array<IColumn<R>>;
     public selection: Set<V>;

--- a/src/react/table.tsx
+++ b/src/react/table.tsx
@@ -8,7 +8,6 @@ import {
     IViewConfig,
     MultiSelectionAdapter,
     NOOP_SELECTION_ADAPTER,
-    ObjectWithKey,
     SelectionHandler,
     SelectionMode,
     SingleSelectionAdapter,
@@ -17,7 +16,7 @@ import {
     TableView
 } from "..";
 
-function createSelectionAdapter<K extends keyof R, R extends ObjectWithKey<K, V>, V = R[K]>(
+function createSelectionAdapter<K extends keyof R, R extends Record<K, V>, V = R[K]>(
     mode: SelectionMode | undefined,
     model: ITableModel<K, R, V>,
     handler: SelectionHandler<V>
@@ -32,7 +31,7 @@ function createSelectionAdapter<K extends keyof R, R extends ObjectWithKey<K, V>
     }
 }
 
-export interface ITableProps<K extends keyof R, R extends ObjectWithKey<K, V>, V = R[K]> {
+export interface ITableProps<K extends keyof R, R extends Record<K, V>, V = R[K]> {
     keyField: K;
     rows: R[];
     columns: Array<IColumn<R>>;
@@ -45,7 +44,7 @@ export interface ITableProps<K extends keyof R, R extends ObjectWithKey<K, V>, V
     onSort?(newSort: ISort): void;
 }
 
-export class Table<K extends keyof R, R extends ObjectWithKey<K, V>, V = R[K]> extends React.PureComponent<
+export class Table<K extends keyof R, R extends Record<K, V>, V = R[K]> extends React.PureComponent<
     ITableProps<K, R, V>
 > {
     private model: ITableModel<K, R, V>;

--- a/src/selection/multi.ts
+++ b/src/selection/multi.ts
@@ -1,4 +1,4 @@
-import { ISelectionAdapter, ITableModel, ObjectWithKey, SelectionHandler } from "../types";
+import { ISelectionAdapter, ITableModel, SelectionHandler } from "../types";
 
 function findIndex<T>(elements: T[], fn: (element: T) => boolean) {
     for (let index = 0; index < elements.length; index++) {
@@ -9,8 +9,7 @@ function findIndex<T>(elements: T[], fn: (element: T) => boolean) {
     return null;
 }
 
-export class MultiSelectionAdapter<K extends keyof R, R extends ObjectWithKey<K, V>, V = R[K]>
-    implements ISelectionAdapter {
+export class MultiSelectionAdapter<K extends keyof R, R extends Record<K, V>, V = R[K]> implements ISelectionAdapter {
     private anchorKey: V | undefined;
 
     public constructor(private model: ITableModel<K, R, V>, private handler: SelectionHandler<V>) {}

--- a/src/selection/single.ts
+++ b/src/selection/single.ts
@@ -1,7 +1,6 @@
-import { ISelectionAdapter, ITableModel, ObjectWithKey, SelectionHandler } from "../types";
+import { ISelectionAdapter, ITableModel, SelectionHandler } from "../types";
 
-export class SingleSelectionAdapter<K extends keyof R, R extends ObjectWithKey<K, V>, V = R[K]>
-    implements ISelectionAdapter {
+export class SingleSelectionAdapter<K extends keyof R, R extends Record<K, V>, V = R[K]> implements ISelectionAdapter {
     public constructor(private model: ITableModel<K, R, V>, private handler: SelectionHandler<V>) {}
 
     public handleRowClick = (_event: MouseEvent, rowIndex: number) => {

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -1,6 +1,6 @@
-import { ISortAdapter, ITableModel, ObjectWithKey, SortHandler } from "./types";
+import { ISortAdapter, ITableModel, SortHandler } from "./types";
 
-export class SortAdapter<K extends keyof R, R extends ObjectWithKey<K, V>, V = R[K]> implements ISortAdapter {
+export class SortAdapter<K extends keyof R, R extends Record<K, V>, V = R[K]> implements ISortAdapter {
     public constructor(private model: ITableModel<K, R, V>, private handler: SortHandler) {}
 
     public handleHeaderClick = (_event: MouseEvent, headerIndex: number) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,3 @@
-export type ObjectWithKey<K extends string | number | symbol, V> = { [T in K]: V };
-
 export interface IColumn<R> {
     key: string;
     label?: string;
@@ -20,7 +18,7 @@ export interface ISort {
     ascending: boolean;
 }
 
-export interface ITableConfig<K extends keyof R, R extends ObjectWithKey<K, V>, V = R[K]> {
+export interface ITableConfig<K extends keyof R, R extends Record<K, V>, V = R[K]> {
     keyField: K;
     rows: R[];
     columns: Array<IColumn<R>>;
@@ -33,7 +31,7 @@ export type ColumnEventListener<R> = (newColumns: Array<IColumn<R>>, oldColumns:
 export type SelectionEventListener<V> = (newSelection: Set<V>, oldSelection: Set<V>) => void;
 export type SortEventListener = (newSort: ISort | undefined, oldSort: ISort | undefined) => void;
 
-export interface ITableModel<K extends keyof R, R extends ObjectWithKey<K, V>, V = R[K]> {
+export interface ITableModel<K extends keyof R, R extends Record<K, V>, V = R[K]> {
     readonly keyField: K;
     readonly columns: Array<IColumn<R>>;
     readonly selection: Set<V>;
@@ -58,7 +56,7 @@ export interface ITableModel<K extends keyof R, R extends ObjectWithKey<K, V>, V
 export type RowClickHandler = (event: MouseEvent, rowIndex: number) => void;
 export type HeaderClickHandler = (event: MouseEvent, headerIndex: number) => void;
 
-export interface IViewConfig<K extends keyof R, R extends ObjectWithKey<K, V>, V = R[K]> {
+export interface IViewConfig<K extends keyof R, R extends Record<K, V>, V = R[K]> {
     model: ITableModel<K, R, V>;
     onClickRow: RowClickHandler;
     onClickHeader: HeaderClickHandler;

--- a/src/view/body.ts
+++ b/src/view/body.ts
@@ -1,4 +1,4 @@
-import { IColumn, ITableModel, ITableSectionView, ObjectWithKey, RowClickHandler } from "../types";
+import { IColumn, ITableModel, ITableSectionView, RowClickHandler } from "../types";
 import { findParentElementOfType, getChildIndex, replaceWith } from "./dom";
 import { union } from "./math";
 
@@ -48,7 +48,7 @@ export function getCellText<R>(row: R, column: IColumn<R>): string {
     }
 }
 
-export class TableBodyView<K extends keyof R, R extends ObjectWithKey<K, V>, V = R[K]> implements ITableSectionView {
+export class TableBodyView<K extends keyof R, R extends Record<K, V>, V = R[K]> implements ITableSectionView {
     public element: HTMLTableSectionElement;
     private trElements: Map<R, HTMLTableRowElement> = new Map();
 

--- a/src/view/fixed-table.ts
+++ b/src/view/fixed-table.ts
@@ -1,4 +1,4 @@
-import { ITableSectionView, ITableView, IViewConfig, ObjectWithKey } from "../types";
+import { ITableSectionView, ITableView, IViewConfig } from "../types";
 import { TableBodyView } from "./body";
 import { applyStyles } from "./dom";
 import { TableHeaderView } from "./header";
@@ -29,7 +29,7 @@ const BODY_ELEMENT_STYLES: Partial<CSSStyleDeclaration> = {
     width: "100%"
 };
 
-export class FixedTableView<K extends keyof R, R extends ObjectWithKey<K, V>, V = R[K]> implements ITableView {
+export class FixedTableView<K extends keyof R, R extends Record<K, V>, V = R[K]> implements ITableView {
     public element: HTMLElement;
     private headerElement: HTMLElement;
     private headerTable: HTMLElement;

--- a/src/view/header.ts
+++ b/src/view/header.ts
@@ -1,4 +1,4 @@
-import { HeaderClickHandler, IColumn, ISort, ITableModel, ITableSectionView, ObjectWithKey } from "../types";
+import { HeaderClickHandler, IColumn, ISort, ITableModel, ITableSectionView } from "../types";
 import { findParentElementOfType, getChildIndex, replaceWith } from "./dom";
 
 export const SORT_ARROW_CLASSNAME = "tpp-sort-arrow";
@@ -12,7 +12,7 @@ function getClickedHeaderIndex(event: MouseEvent) {
     }
 }
 
-export class TableHeaderView<K extends keyof R, R extends ObjectWithKey<K, V>, V = R[K]> implements ITableSectionView {
+export class TableHeaderView<K extends keyof R, R extends Record<K, V>, V = R[K]> implements ITableSectionView {
     public element: HTMLTableSectionElement;
     private thElements: Map<IColumn<R>, HTMLTableHeaderCellElement> = new Map();
 

--- a/src/view/table.ts
+++ b/src/view/table.ts
@@ -1,8 +1,8 @@
-import { ITableSectionView, ITableView, IViewConfig, ObjectWithKey } from "../types";
+import { ITableSectionView, ITableView, IViewConfig } from "../types";
 import { TableBodyView } from "./body";
 import { TableHeaderView } from "./header";
 
-export class TableView<K extends keyof R, R extends ObjectWithKey<K, V>, V = R[K]> implements ITableView {
+export class TableView<K extends keyof R, R extends Record<K, V>, V = R[K]> implements ITableView {
     public element: HTMLTableElement;
     public headerView: ITableSectionView;
     public bodyView: ITableSectionView;


### PR DESCRIPTION
Replace the `ObjectWithKey` type with the native `Record` type.